### PR TITLE
Add "clear: both" to scene titles so they have enough vertical space

### DIFF
--- a/src/files/drama.css
+++ b/src/files/drama.css
@@ -608,6 +608,7 @@ tei-TEI tei-head {
   display: block;
   font-family: Arvo, sans-serif;
   font-weight: normal;
+  clear: both;
 }
 tei-body > tei-head {
   font-size: 180%;


### PR DESCRIPTION
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4827

### Before
![MicrosoftTeams-image](https://user-images.githubusercontent.com/639920/120692534-e3fa9500-c475-11eb-916f-a14e81e7517e.png)

### After
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/639920/120692542-e6f58580-c475-11eb-8b4a-a60dd19e42da.png)