### PR TITLE
Add margin to centered stage directions to fix overlap issues

### DIFF
--- a/src/files/drama.css
+++ b/src/files/drama.css
@@ -1674,7 +1674,7 @@ tei-stage[place=center] {
   text-align: center;
   min-width: 35em;
   width: 100%;
-  margin-left: auto;
+  margin-left: 5.95em;
   margin-right: auto;
 }
 tei-stage[place=right] {


### PR DESCRIPTION
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4834

### Before:
<img width="750" alt="Screen Shot 2021-07-01 at 10 06 42 AM" src="https://user-images.githubusercontent.com/639920/124138674-dfb19f80-da54-11eb-9cce-4939f2391deb.png">

### After:
<img width="763" alt="Screen Shot 2021-07-01 at 10 06 35 AM" src="https://user-images.githubusercontent.com/639920/124138692-e4765380-da54-11eb-99d6-283b43cd252a.png">
