### PR TITLE
Add a scroll offset to <tei-l> so page targets don't load behind header

### DIFF
--- a/src/files/drama.css
+++ b/src/files/drama.css
@@ -774,6 +774,7 @@ tei-l {
   display: block;
   width: 90%;
   padding-left: 6em;
+  scroll-margin-top: 40px;
 }
 tei-l[data-lineno]:before {
   content: attr(data-lineno);


### PR DESCRIPTION
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4833

### Before
<img width="1441" alt="Screen Shot 2021-07-01 at 2 38 19 PM" src="https://user-images.githubusercontent.com/639920/124174229-1bab2b80-da7a-11eb-86c9-20847ce886f5.png">

### After
<img width="1481" alt="Screen Shot 2021-07-01 at 2 37 43 PM" src="https://user-images.githubusercontent.com/639920/124174249-206fdf80-da7a-11eb-8e5b-4b5e576827d9.png">
